### PR TITLE
Set fork property as false in configuration of plugin in order to build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,7 @@
                     <api>JDO</api>
                     <persistenceUnitName>Alpine</persistenceUnitName>
                     <verbose>true</verbose>
+                    <fork>false</fork>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
 Set fork property as false in configuration of plugin in order to build.